### PR TITLE
- add fields idToken and accessToken

### DIFF
--- a/lib/src/google_sign_in_mocks_base.dart
+++ b/lib/src/google_sign_in_mocks_base.dart
@@ -15,4 +15,10 @@ class MockGoogleSignInAccount extends Mock implements GoogleSignInAccount {
 }
 
 class MockGoogleSignInAuthentication extends Mock
-    implements GoogleSignInAuthentication {}
+    implements GoogleSignInAuthentication {
+  @override
+  String get idToken => 'idToken';
+
+  @override
+  String get accessToken => 'accessToken';
+}

--- a/lib/src/google_sign_in_mocks_base.dart
+++ b/lib/src/google_sign_in_mocks_base.dart
@@ -2,9 +2,15 @@ import 'package:google_sign_in/google_sign_in.dart';
 import 'package:mockito/mockito.dart';
 
 class MockGoogleSignIn extends Mock implements GoogleSignIn {
+  MockGoogleSignInAccount _currentUser;
+
+  @override
+  GoogleSignInAccount get currentUser => _currentUser;
+
   @override
   Future<GoogleSignInAccount> signIn() {
-    return Future.value(MockGoogleSignInAccount());
+    _currentUser = MockGoogleSignInAccount();
+    return Future.value(_currentUser);
   }
 }
 

--- a/test/google_sign_in_mocks_test.dart
+++ b/test/google_sign_in_mocks_test.dart
@@ -2,10 +2,13 @@ import 'package:google_sign_in_mocks/google_sign_in_mocks.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test('Basic test', () async {
+  test('should return idToken and accessToken when authenticating', () async {
     final googleSignIn = MockGoogleSignIn();
-    final signinAccount = await googleSignIn.signIn();
-    final signinAuthentication = await signinAccount.authentication;
-    expect(signinAuthentication, isNotNull);
+    final signInAccount = await googleSignIn.signIn();
+    final signInAuthentication = await signInAccount.authentication;
+    expect(signInAuthentication, isNotNull);
+    expect(signInAuthentication.accessToken, isNotNull);
+    expect(signInAuthentication.idToken, isNotNull);
   });
+
 }

--- a/test/google_sign_in_mocks_test.dart
+++ b/test/google_sign_in_mocks_test.dart
@@ -7,6 +7,7 @@ void main() {
     final signInAccount = await googleSignIn.signIn();
     final signInAuthentication = await signInAccount.authentication;
     expect(signInAuthentication, isNotNull);
+    expect(googleSignIn.currentUser, isNotNull);
     expect(signInAuthentication.accessToken, isNotNull);
     expect(signInAuthentication.idToken, isNotNull);
   });


### PR DESCRIPTION
Calling GoogleAuthProvider.credential requires either idToken or accessToken without which would result in 
'package:firebase_auth_platform_interface/src/providers/google_auth.dart': Failed assertion: line 81 pos 12: 'accessToken != nul;

PS. I couldn't actually get the test to run in my local. I'm just assuming that it runs correctly somewhere on your build target. Something about non-nullable. 