### PR TITLE
Support google_sign_in 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.0
+
+- Updated dependency to google_signin 7.0.0.
+
 ## 0.3.0
 
 - Updated dependency to google_signin 6.1.2. Thank you [MedwinCorreo](https://github.com/atn832/google_sign_in_mocks/pull/8)!

--- a/lib/src/google_sign_in_mocks_base.dart
+++ b/lib/src/google_sign_in_mocks_base.dart
@@ -25,8 +25,8 @@ class MockGoogleSignIn implements GoogleSignIn {
 
 class MockGoogleSignInAccount implements GoogleSignInAccount {
   @override
-  Future<GoogleSignInAuthentication> get authentication =>
-      Future.value(MockGoogleSignInAuthentication());
+  GoogleSignInAuthentication get authentication =>
+      MockGoogleSignInAuthentication();
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
@@ -35,9 +35,6 @@ class MockGoogleSignInAccount implements GoogleSignInAccount {
 class MockGoogleSignInAuthentication implements GoogleSignInAuthentication {
   @override
   String get idToken => 'idToken';
-
-  @override
-  String get accessToken => 'accessToken';
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);

--- a/lib/src/google_sign_in_mocks_base.dart
+++ b/lib/src/google_sign_in_mocks_base.dart
@@ -11,12 +11,13 @@ class MockGoogleSignIn implements GoogleSignIn {
   }
 
   @override
-  GoogleSignInAccount? get currentUser => _currentUser;
-
-  @override
-  Future<GoogleSignInAccount?> signIn() {
+  Future<GoogleSignInAccount> authenticate(
+      {List<String> scopeHint = const <String>[]}) {
     _currentUser = MockGoogleSignInAccount();
-    return Future.value(_isCancelled ? null : _currentUser);
+    if (_isCancelled) {
+      return Future.error('Cancelled');
+    }
+    return Future.value(_currentUser);
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: google_sign_in_mocks
 description: Mocks for Google Sign In. Use this package with `firebase_auth_mocks` to write unit tests involving Firebase Authentication.
-version: 0.3.0
+version: 0.4.0
 homepage: https://www.wafrat.com
 repository: https://github.com/atn832/google_sign_in_mocks
 
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  google_sign_in: ^6.1.2
+  google_sign_in: ^7.0.0
 
 dev_dependencies:
   flutter_test:

--- a/test/google_sign_in_mocks_test.dart
+++ b/test/google_sign_in_mocks_test.dart
@@ -12,7 +12,6 @@ void main() {
     final signInAuthentication = await signInAccount!.authentication;
     expect(signInAuthentication, isNotNull);
     expect(googleSignIn.currentUser, isNotNull);
-    expect(signInAuthentication.accessToken, isNotNull);
     expect(signInAuthentication.idToken, isNotNull);
   });
 
@@ -22,8 +21,10 @@ void main() {
     final signInAccount = await googleSignIn.signIn();
     expect(signInAccount, isNull);
   });
-  test('testing google login twice, once cancelled, once not cancelled at the same test.', () async {
-   googleSignIn.setIsCancelled(true);
+  test(
+      'testing google login twice, once cancelled, once not cancelled at the same test.',
+      () async {
+    googleSignIn.setIsCancelled(true);
     final signInAccount = await googleSignIn.signIn();
     expect(signInAccount, isNull);
     googleSignIn.setIsCancelled(false);

--- a/test/google_sign_in_mocks_test.dart
+++ b/test/google_sign_in_mocks_test.dart
@@ -8,27 +8,28 @@ void main() {
   });
 
   test('should return idToken and accessToken when authenticating', () async {
-    final signInAccount = await googleSignIn.signIn();
-    final signInAuthentication = await signInAccount!.authentication;
+    final signInAccount = await googleSignIn.authenticate();
+    final signInAuthentication = signInAccount.authentication;
     expect(signInAuthentication, isNotNull);
-    expect(googleSignIn.currentUser, isNotNull);
     expect(signInAuthentication.idToken, isNotNull);
   });
 
-  test('should return null when google login is cancelled by the user',
+  test('should cancel the Future when google login is cancelled by the user',
       () async {
     googleSignIn.setIsCancelled(true);
-    final signInAccount = await googleSignIn.signIn();
-    expect(signInAccount, isNull);
+    expect(() {
+      return googleSignIn.authenticate();
+    }, throwsA('Cancelled'));
   });
   test(
       'testing google login twice, once cancelled, once not cancelled at the same test.',
       () async {
     googleSignIn.setIsCancelled(true);
-    final signInAccount = await googleSignIn.signIn();
-    expect(signInAccount, isNull);
+    expect(() {
+      return googleSignIn.authenticate();
+    }, throwsA('Cancelled'));
     googleSignIn.setIsCancelled(false);
-    final signInAccountSecondAttempt = await googleSignIn.signIn();
+    final signInAccountSecondAttempt = await googleSignIn.authenticate();
     expect(signInAccountSecondAttempt, isNotNull);
   });
 }


### PR DESCRIPTION
The biggest change from 6 to 7 is that the `signIn` method has been changed to `authenticate` and that `currentUser` is no longer available.

I've also noticed that google_sign_in now provides some classes for tests, but I've yet to read what they do in detail. https://pub.dev/documentation/google_sign_in/latest/testing/
<img width="1242" height="395" alt="image" src="https://github.com/user-attachments/assets/0fd19154-7ee6-40a7-bf32-37bd4995eaf9" />
